### PR TITLE
Possibility to add more fields in logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 coverage.out
+.idea

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ func main() {
         stomp.SendOpt.Header("persistent", "true"),
     )
 
+    // If you want to add new fields in logs
+    sc.AddLogField("testKey", "testValue")
+
     name := "queueName"
     body := []byte("queueBody")
-    
-    // If you want to add new fields in logs
-    enqueuestomp.AddLogField("testKey", "testValue")
 
     err := enqueue.SendQueue(name, body, sc)
     if err != nil {

--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ func main() {
     body := []byte("queueBody")
     
     // If you want to add new fields in logs
-    logField := enqueuestomp.NewLogField()
-    logField.SetNewField("testKey", "testValue")
+    enqueuestomp.AddLogField("testKey", "testValue")
 
-    err := enqueue.SendQueue(name, body, sc, logField)
+    err := enqueue.SendQueue(name, body, sc)
     if err != nil {
         fmt.Printf("error %s", err)
     }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ func main() {
 
     name := "queueName"
     body := []byte("queueBody")
-    err := enqueue.SendQueue(name, body, sc)
+    
+    // If you want to add new fields in logs
+    logField := enqueuestomp.NewLogField()
+    logField.SetNewField("testKey", "testValue")
+
+    err := enqueue.SendQueue(name, body, sc, logField)
     if err != nil {
         fmt.Printf("error %s", err)
     }

--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -66,7 +66,7 @@ func (cb *CircuitBreakerConfig) init() {
 	}
 }
 
-func (emq *EnqueueStomp) ConfigureCircuitBreaker(name string, cb CircuitBreakerConfig) {
+func (emq *EnqueueStompImpl) ConfigureCircuitBreaker(name string, cb CircuitBreakerConfig) {
 	emq.mu.Lock()
 	defer emq.mu.Unlock()
 
@@ -82,7 +82,7 @@ func (emq *EnqueueStomp) ConfigureCircuitBreaker(name string, cb CircuitBreakerC
 	emq.circuitNames[circuitName] = circuitName
 }
 
-func (emq *EnqueueStomp) sendWithCircuitBreaker(identifier string, destination string, body []byte, sc SendConfig) error {
+func (emq *EnqueueStompImpl) sendWithCircuitBreaker(identifier string, destination string, body []byte, sc SendConfig) error {
 	circuitName := emq.makeCircuitName(sc.CircuitName)
 	err := hystrix.Do(circuitName, func() error {
 		emq.debugLogger(
@@ -95,11 +95,11 @@ func (emq *EnqueueStomp) sendWithCircuitBreaker(identifier string, destination s
 	return err
 }
 
-func (emq *EnqueueStomp) makeCircuitName(name string) string {
+func (emq *EnqueueStompImpl) makeCircuitName(name string) string {
 	return fmt.Sprintf("%s::%s", name, emq.id)
 }
 
-func (emq *EnqueueStomp) hasCircuitBreaker(sc SendConfig) bool {
+func (emq *EnqueueStompImpl) hasCircuitBreaker(sc SendConfig) bool {
 	if sc.CircuitName == "" {
 		return false
 	}

--- a/enqueuestomp.go
+++ b/enqueuestomp.go
@@ -82,7 +82,7 @@ func NewEnqueueStomp(config Config) (EnqueueStomp, error) {
 // The body array contains the message body,
 // and its content should be consistent with the specified content type.
 func (emq *EnqueueStompImpl) SendQueue(queueName string, body []byte, sc SendConfig) error {
-	if queueName == "" || strings.TrimSpace(queueName) == "" {
+	if strings.TrimSpace(queueName) == "" {
 		return ErrEmptyQueueName
 	}
 	return emq.send(DestinationTypeQueue, queueName, body, sc)
@@ -92,7 +92,7 @@ func (emq *EnqueueStompImpl) SendQueue(queueName string, body []byte, sc SendCon
 // The body array contains the message body,
 // and its content should be consistent with the specified content type.
 func (emq *EnqueueStompImpl) SendTopic(topicName string, body []byte, sc SendConfig) error {
-	if topicName == "" || strings.TrimSpace(topicName) == "" {
+	if strings.TrimSpace(topicName) == "" {
 		return ErrEmptyTopicName
 	}
 

--- a/enqueuestomp.go
+++ b/enqueuestomp.go
@@ -70,22 +70,22 @@ func NewEnqueueStomp(config Config) (*EnqueueStomp, error) {
 // SendQueue
 // The body array contains the message body,
 // and its content should be consistent with the specified content type.
-func (emq *EnqueueStomp) SendQueue(queueName string, body []byte, sc SendConfig) error {
+func (emq *EnqueueStomp) SendQueue(queueName string, body []byte, sc SendConfig, logField LogField) error {
 	if queueName == "" || strings.TrimSpace(queueName) == "" {
 		return ErrEmptyQueueName
 	}
-	return emq.send(DestinationTypeQueue, queueName, body, sc)
+	return emq.send(DestinationTypeQueue, queueName, body, sc, logField)
 }
 
 // SendTopic
 // The body array contains the message body,
 // and its content should be consistent with the specified content type.
-func (emq *EnqueueStomp) SendTopic(topicName string, body []byte, sc SendConfig) error {
+func (emq *EnqueueStomp) SendTopic(topicName string, body []byte, sc SendConfig, logField LogField) error {
 	if topicName == "" || strings.TrimSpace(topicName) == "" {
 		return ErrEmptyTopicName
 	}
 
-	return emq.send(DestinationTypeTopic, topicName, body, sc)
+	return emq.send(DestinationTypeTopic, topicName, body, sc, logField)
 }
 
 func (emq *EnqueueStomp) QueueSize() int {
@@ -108,14 +108,14 @@ func (emq *EnqueueStomp) Disconnect() error {
 	return emq.conn.Disconnect()
 }
 
-func (emq *EnqueueStomp) send(destinationType string, destinationName string, body []byte, sc SendConfig) error {
+func (emq *EnqueueStomp) send(destinationType string, destinationName string, body []byte, sc SendConfig, logField LogField) error {
 	if len(body) == 0 {
 		return ErrEmptyBody
 	}
 	sc.init()
 
 	identifier := emq.config.IdentifierFunc()
-	emq.writeOutput("before", identifier, destinationType, destinationName, body)
+	emq.writeOutput("before", identifier, destinationType, destinationName, body, logField)
 
 	emq.wp.Submit(func() {
 		var err error
@@ -152,7 +152,7 @@ func (emq *EnqueueStomp) send(destinationType string, destinationName string, bo
 			}
 		}
 
-		emq.writeOutput("after", identifier, destinationType, destinationName, body)
+		emq.writeOutput("after", identifier, destinationType, destinationName, body, logField)
 		if sc.AfterSend != nil {
 			sc.AfterSend(identifier, destinationType, destinationName, body, startTime, err)
 		}

--- a/enqueuestomp.go
+++ b/enqueuestomp.go
@@ -30,7 +30,18 @@ var (
 	DefaultBodyCheck    = []byte("PING")
 )
 
-type EnqueueStomp struct {
+type EnqueueStomp interface {
+	SendQueue(queueName string, body []byte, sc SendConfig, logField LogField) error
+	SendTopic(topicName string, body []byte, sc SendConfig, logField LogField) error
+	QueueSize() int
+	Config() Config
+	CheckQueue(queueName string) error
+	CheckTopic(topicName string) error
+	Disconnect() error
+	ConfigureCircuitBreaker(name string, cb CircuitBreakerConfig)
+}
+
+type EnqueueStompImpl struct {
 	id           string
 	config       Config
 	mu           sync.RWMutex
@@ -43,10 +54,10 @@ type EnqueueStomp struct {
 	log          Logger
 }
 
-func NewEnqueueStomp(config Config) (*EnqueueStomp, error) {
+func NewEnqueueStomp(config Config) (EnqueueStomp, error) {
 	config.init()
 
-	emq := &EnqueueStomp{
+	emq := &EnqueueStompImpl{
 		id:           config.IdentifierFunc(),
 		config:       config,
 		wp:           workerpool.New(config.MaxWorkers),
@@ -70,7 +81,7 @@ func NewEnqueueStomp(config Config) (*EnqueueStomp, error) {
 // SendQueue
 // The body array contains the message body,
 // and its content should be consistent with the specified content type.
-func (emq *EnqueueStomp) SendQueue(queueName string, body []byte, sc SendConfig, logField LogField) error {
+func (emq *EnqueueStompImpl) SendQueue(queueName string, body []byte, sc SendConfig, logField LogField) error {
 	if queueName == "" || strings.TrimSpace(queueName) == "" {
 		return ErrEmptyQueueName
 	}
@@ -80,7 +91,7 @@ func (emq *EnqueueStomp) SendQueue(queueName string, body []byte, sc SendConfig,
 // SendTopic
 // The body array contains the message body,
 // and its content should be consistent with the specified content type.
-func (emq *EnqueueStomp) SendTopic(topicName string, body []byte, sc SendConfig, logField LogField) error {
+func (emq *EnqueueStompImpl) SendTopic(topicName string, body []byte, sc SendConfig, logField LogField) error {
 	if topicName == "" || strings.TrimSpace(topicName) == "" {
 		return ErrEmptyTopicName
 	}
@@ -88,27 +99,27 @@ func (emq *EnqueueStomp) SendTopic(topicName string, body []byte, sc SendConfig,
 	return emq.send(DestinationTypeTopic, topicName, body, sc, logField)
 }
 
-func (emq *EnqueueStomp) QueueSize() int {
+func (emq *EnqueueStompImpl) QueueSize() int {
 	return emq.wp.WaitingQueueSize()
 }
 
-func (emq *EnqueueStomp) Config() Config {
+func (emq *EnqueueStompImpl) Config() Config {
 	return emq.config
 }
 
-func (emq *EnqueueStomp) CheckQueue(queueName string) error {
+func (emq *EnqueueStompImpl) CheckQueue(queueName string) error {
 	return emq.check(DestinationTypeQueue, queueName)
 }
 
-func (emq *EnqueueStomp) CheckTopic(topicName string) error {
+func (emq *EnqueueStompImpl) CheckTopic(topicName string) error {
 	return emq.check(DestinationTypeTopic, topicName)
 }
 
-func (emq *EnqueueStomp) Disconnect() error {
+func (emq *EnqueueStompImpl) Disconnect() error {
 	return emq.conn.Disconnect()
 }
 
-func (emq *EnqueueStomp) send(destinationType string, destinationName string, body []byte, sc SendConfig, logField LogField) error {
+func (emq *EnqueueStompImpl) send(destinationType string, destinationName string, body []byte, sc SendConfig, logField LogField) error {
 	if len(body) == 0 {
 		return ErrEmptyBody
 	}
@@ -162,7 +173,7 @@ func (emq *EnqueueStomp) send(destinationType string, destinationName string, bo
 }
 
 // NewConn Creates a new conn to broker.
-func (emq *EnqueueStomp) newConn(identifier string) (err error) {
+func (emq *EnqueueStompImpl) newConn(identifier string) (err error) {
 	emq.mu.Lock()
 	defer emq.mu.Unlock()
 	if atomic.LoadInt32(&emq.connected) != 0 {
@@ -201,7 +212,7 @@ func (emq *EnqueueStomp) newConn(identifier string) (err error) {
 	return err
 }
 
-func (emq *EnqueueStomp) check(destinationType string, destinationName string) error {
+func (emq *EnqueueStompImpl) check(destinationType string, destinationName string) error {
 	destination := fmt.Sprintf("/%s/%s", destinationType, destinationName)
 	unixTimeInMilliSeconds := time.Now().Add(DefaultExpiresCheck).UnixNano() / int64(time.Millisecond)
 	contentType := "text/plain"

--- a/enqueuestomp_test.go
+++ b/enqueuestomp_test.go
@@ -215,9 +215,9 @@ func (s *EnqueueStompSuite) TestSendQueue(c *check.C) {
 		enqueuestomp.Config{},
 	)
 	c.Assert(err, check.IsNil)
-	enqueue.AddLogField("testKey", "testCase")
 
 	sc := enqueuestomp.SendConfig{}
+	sc.AddLogField("testKey", "testCase")
 	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
@@ -250,7 +250,7 @@ func (s *EnqueueStompSuite) TestSendQueueWithBeforeAfterSend(c *check.C) {
 		},
 	}
 
-	enqueue.AddLogField("testKey", "testCase")
+	sc.AddLogField("testKey", "testCase")
 
 	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
@@ -266,9 +266,9 @@ func (s *EnqueueStompSuite) TestSendQueueBodyEmpty(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	enqueue.AddLogField("testKey", "testCase")
-
 	sc := enqueuestomp.SendConfig{}
+	sc.AddLogField("testKey", "testCase")
+
 	err = enqueue.SendQueue(queueName, nil, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
@@ -279,9 +279,8 @@ func (s *EnqueueStompSuite) TestSendTopicBodyEmpty(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	enqueue.AddLogField("testKey", "testCase")
-
 	sc := enqueuestomp.SendConfig{}
+	sc.AddLogField("testKey", "testCase")
 	err = enqueue.SendTopic(topicName, nil, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
@@ -293,8 +292,7 @@ func (s *EnqueueStompSuite) TestSendQueueNameEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-
-	enqueue.AddLogField("testKey", "testCase")
+	sc.AddLogField("testKey", "testCase")
 
 	err = enqueue.SendQueue("", queueBody, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyQueueName)
@@ -308,7 +306,7 @@ func (s *EnqueueStompSuite) TestSendTopicNameEmpty(c *check.C) {
 
 	sc := enqueuestomp.SendConfig{}
 
-	enqueue.AddLogField("testKey", "testCase")
+	sc.AddLogField("testKey", "testCase")
 
 	err = enqueue.SendTopic("", topicBody, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyTopicName)
@@ -323,7 +321,7 @@ func (s *EnqueueStompSuite) TestSendQueueWritePersistent(c *check.C) {
 	sc := enqueuestomp.SendConfig{}
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 
-	enqueue.AddLogField("testKey", "testCase")
+	sc.AddLogField("testKey", "testCase")
 
 	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
@@ -348,7 +346,7 @@ func (s *EnqueueStompSuite) TestSendQueueWithCircuitBreaker(c *check.C) {
 		CircuitName: "circuit-enqueuestomp",
 	}
 
-	enqueue.AddLogField("testKey", "testCase")
+	sc.AddLogField("testKey", "testCase")
 
 	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
@@ -366,11 +364,10 @@ func (s *EnqueueStompSuite) TestSendQueueWithWriteDisk(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	enqueue.AddLogField("testKey", "testCase")
-
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
+		sc.AddLogField("testKey", "testCase")
 		err = enqueue.SendQueue(queueName, queueBody, sc)
 		c.Assert(err, check.IsNil)
 	}
@@ -389,11 +386,10 @@ func (s *EnqueueStompSuite) TestSendTopic(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	enqueue.AddLogField("testKey", "testCase")
-
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
+		sc.AddLogField("testKey", "testCase")
 		err = enqueue.SendTopic(topicName, topicBody, sc)
 		c.Assert(err, check.IsNil)
 	}
@@ -411,11 +407,10 @@ func (s *EnqueueStompSuite) TestSendTopicWithWriteDisk(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	enqueue.AddLogField("testKey", "testCase")
-
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
+		sc.AddLogField("testKey", "testCase")
 		err = enqueue.SendTopic(topicName, topicBody, sc)
 		c.Assert(err, check.IsNil)
 	}
@@ -452,7 +447,7 @@ func (s *EnqueueStompSuite) TestSendConfigOptions(c *check.C) {
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 	c.Assert(sc.Options, check.HasLen, 1)
 
-	enqueue.AddLogField("testKey", "testCase")
+	sc.AddLogField("testKey", "testCase")
 
 	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
@@ -476,9 +471,8 @@ func (s *EnqueueStompSuite) TestConfigOptions(c *check.C) {
 	enqueue, err := enqueuestomp.NewEnqueueStomp(enqueueConfig)
 	c.Assert(err, check.IsNil)
 
-	enqueue.AddLogField("testKey", "testCase")
-
 	sc := enqueuestomp.SendConfig{}
+	sc.AddLogField("testKey", "testCase")
 	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
@@ -497,7 +491,7 @@ func (s *EnqueueStompSuite) TestSendConfigLogger(c *check.C) {
 
 	sc := enqueuestomp.SendConfig{}
 
-	enqueue.AddLogField("testKey", "testCase")
+	sc.AddLogField("testKey", "testCase")
 
 	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
@@ -516,8 +510,6 @@ func (s *EnqueueStompSuite) TestSend(c *check.C) {
 	err = enqueue.Disconnect()
 	c.Assert(err, check.IsNil)
 
-	enqueue.AddLogField("testKey", "testCase")
-
 	var wg sync.WaitGroup
 	total := 1500
 	for i := 0; i < total; i++ {
@@ -525,6 +517,7 @@ func (s *EnqueueStompSuite) TestSend(c *check.C) {
 		go func() {
 			defer wg.Done()
 			sc := enqueuestomp.SendConfig{}
+			sc.AddLogField("testKey", "testCase")
 			err := enqueue.SendTopic(topicName, topicBody, sc)
 			c.Assert(err, check.IsNil)
 		}()

--- a/enqueuestomp_test.go
+++ b/enqueuestomp_test.go
@@ -216,8 +216,11 @@ func (s *EnqueueStompSuite) TestSendQueue(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -248,7 +251,11 @@ func (s *EnqueueStompSuite) TestSendQueueWithBeforeAfterSend(c *check.C) {
 			c.Assert(err, check.IsNil)
 		},
 	}
-	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
+	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -262,8 +269,11 @@ func (s *EnqueueStompSuite) TestSendQueueBodyEmpty(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, nil, sc, nil)
+	err = enqueue.SendQueue(queueName, nil, sc, logField)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
 
@@ -273,8 +283,11 @@ func (s *EnqueueStompSuite) TestSendTopicBodyEmpty(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendTopic(topicName, nil, sc, nil)
+	err = enqueue.SendTopic(topicName, nil, sc, logField)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
 
@@ -285,7 +298,11 @@ func (s *EnqueueStompSuite) TestSendQueueNameEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue("", queueBody, sc, nil)
+
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
+	err = enqueue.SendQueue("", queueBody, sc, logField)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyQueueName)
 }
 
@@ -296,7 +313,11 @@ func (s *EnqueueStompSuite) TestSendTopicNameEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendTopic("", topicBody, sc, nil)
+
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
+	err = enqueue.SendTopic("", topicBody, sc, logField)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyTopicName)
 }
 
@@ -309,7 +330,10 @@ func (s *EnqueueStompSuite) TestSendQueueWritePersistent(c *check.C) {
 	sc := enqueuestomp.SendConfig{}
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 
-	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
+	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -331,7 +355,11 @@ func (s *EnqueueStompSuite) TestSendQueueWithCircuitBreaker(c *check.C) {
 	sc := enqueuestomp.SendConfig{
 		CircuitName: "circuit-enqueuestomp",
 	}
-	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
+	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -347,10 +375,13 @@ func (s *EnqueueStompSuite) TestSendQueueWithWriteDisk(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+		err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -368,10 +399,13 @@ func (s *EnqueueStompSuite) TestSendTopic(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendTopic(topicName, topicBody, sc, nil)
+		err = enqueue.SendTopic(topicName, topicBody, sc, logField)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -388,10 +422,13 @@ func (s *EnqueueStompSuite) TestSendTopicWithWriteDisk(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendTopic(topicName, topicBody, sc, nil)
+		err = enqueue.SendTopic(topicName, topicBody, sc, logField)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -427,7 +464,10 @@ func (s *EnqueueStompSuite) TestSendConfigOptions(c *check.C) {
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 	c.Assert(sc.Options, check.HasLen, 1)
 
-	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
+	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -449,8 +489,11 @@ func (s *EnqueueStompSuite) TestConfigOptions(c *check.C) {
 	enqueue, err := enqueuestomp.NewEnqueueStomp(enqueueConfig)
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -467,7 +510,11 @@ func (s *EnqueueStompSuite) TestSendConfigLogger(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
+
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
+	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -484,6 +531,9 @@ func (s *EnqueueStompSuite) TestSend(c *check.C) {
 	err = enqueue.Disconnect()
 	c.Assert(err, check.IsNil)
 
+	logField := enqueuestomp.NewLogField()
+	logField.SetNewField("testKey", "testValue")
+
 	var wg sync.WaitGroup
 	total := 1500
 	for i := 0; i < total; i++ {
@@ -491,7 +541,7 @@ func (s *EnqueueStompSuite) TestSend(c *check.C) {
 		go func() {
 			defer wg.Done()
 			sc := enqueuestomp.SendConfig{}
-			err := enqueue.SendTopic(topicName, topicBody, sc, nil)
+			err := enqueue.SendTopic(topicName, topicBody, sc, logField)
 			c.Assert(err, check.IsNil)
 		}()
 	}

--- a/enqueuestomp_test.go
+++ b/enqueuestomp_test.go
@@ -215,12 +215,10 @@ func (s *EnqueueStompSuite) TestSendQueue(c *check.C) {
 		enqueuestomp.Config{},
 	)
 	c.Assert(err, check.IsNil)
-
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -252,10 +250,9 @@ func (s *EnqueueStompSuite) TestSendQueueWithBeforeAfterSend(c *check.C) {
 		},
 	}
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
-	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -269,11 +266,10 @@ func (s *EnqueueStompSuite) TestSendQueueBodyEmpty(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, nil, sc, logField)
+	err = enqueue.SendQueue(queueName, nil, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
 
@@ -283,11 +279,10 @@ func (s *EnqueueStompSuite) TestSendTopicBodyEmpty(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendTopic(topicName, nil, sc, logField)
+	err = enqueue.SendTopic(topicName, nil, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
 
@@ -299,10 +294,9 @@ func (s *EnqueueStompSuite) TestSendQueueNameEmpty(c *check.C) {
 
 	sc := enqueuestomp.SendConfig{}
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
-	err = enqueue.SendQueue("", queueBody, sc, logField)
+	err = enqueue.SendQueue("", queueBody, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyQueueName)
 }
 
@@ -314,10 +308,9 @@ func (s *EnqueueStompSuite) TestSendTopicNameEmpty(c *check.C) {
 
 	sc := enqueuestomp.SendConfig{}
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
-	err = enqueue.SendTopic("", topicBody, sc, logField)
+	err = enqueue.SendTopic("", topicBody, sc)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyTopicName)
 }
 
@@ -330,10 +323,9 @@ func (s *EnqueueStompSuite) TestSendQueueWritePersistent(c *check.C) {
 	sc := enqueuestomp.SendConfig{}
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
-	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -356,10 +348,9 @@ func (s *EnqueueStompSuite) TestSendQueueWithCircuitBreaker(c *check.C) {
 		CircuitName: "circuit-enqueuestomp",
 	}
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
-	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -375,13 +366,12 @@ func (s *EnqueueStompSuite) TestSendQueueWithWriteDisk(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+		err = enqueue.SendQueue(queueName, queueBody, sc)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -399,13 +389,12 @@ func (s *EnqueueStompSuite) TestSendTopic(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendTopic(topicName, topicBody, sc, logField)
+		err = enqueue.SendTopic(topicName, topicBody, sc)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -422,13 +411,12 @@ func (s *EnqueueStompSuite) TestSendTopicWithWriteDisk(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendTopic(topicName, topicBody, sc, logField)
+		err = enqueue.SendTopic(topicName, topicBody, sc)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -464,10 +452,9 @@ func (s *EnqueueStompSuite) TestSendConfigOptions(c *check.C) {
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 	c.Assert(sc.Options, check.HasLen, 1)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
-	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -489,11 +476,10 @@ func (s *EnqueueStompSuite) TestConfigOptions(c *check.C) {
 	enqueue, err := enqueuestomp.NewEnqueueStomp(enqueueConfig)
 	c.Assert(err, check.IsNil)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -511,10 +497,9 @@ func (s *EnqueueStompSuite) TestSendConfigLogger(c *check.C) {
 
 	sc := enqueuestomp.SendConfig{}
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
-	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
+	err = enqueue.SendQueue(queueName, queueBody, sc)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -531,8 +516,7 @@ func (s *EnqueueStompSuite) TestSend(c *check.C) {
 	err = enqueue.Disconnect()
 	c.Assert(err, check.IsNil)
 
-	logField := enqueuestomp.NewLogField()
-	logField.SetNewField("testKey", "testValue")
+	enqueue.AddLogField("testKey", "testCase")
 
 	var wg sync.WaitGroup
 	total := 1500
@@ -541,7 +525,7 @@ func (s *EnqueueStompSuite) TestSend(c *check.C) {
 		go func() {
 			defer wg.Done()
 			sc := enqueuestomp.SendConfig{}
-			err := enqueue.SendTopic(topicName, topicBody, sc, logField)
+			err := enqueue.SendTopic(topicName, topicBody, sc)
 			c.Assert(err, check.IsNil)
 		}()
 	}

--- a/enqueuestomp_test.go
+++ b/enqueuestomp_test.go
@@ -217,7 +217,7 @@ func (s *EnqueueStompSuite) TestSendQueue(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc)
+	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -248,7 +248,7 @@ func (s *EnqueueStompSuite) TestSendQueueWithBeforeAfterSend(c *check.C) {
 			c.Assert(err, check.IsNil)
 		},
 	}
-	err = enqueue.SendQueue(queueName, queueBody, sc)
+	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -263,7 +263,7 @@ func (s *EnqueueStompSuite) TestSendQueueBodyEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, nil, sc)
+	err = enqueue.SendQueue(queueName, nil, sc, nil)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
 
@@ -274,7 +274,7 @@ func (s *EnqueueStompSuite) TestSendTopicBodyEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendTopic(topicName, nil, sc)
+	err = enqueue.SendTopic(topicName, nil, sc, nil)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyBody)
 }
 
@@ -285,7 +285,7 @@ func (s *EnqueueStompSuite) TestSendQueueNameEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue("", queueBody, sc)
+	err = enqueue.SendQueue("", queueBody, sc, nil)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyQueueName)
 }
 
@@ -296,7 +296,7 @@ func (s *EnqueueStompSuite) TestSendTopicNameEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendTopic("", topicBody, sc)
+	err = enqueue.SendTopic("", topicBody, sc, nil)
 	c.Assert(err, check.Equals, enqueuestomp.ErrEmptyTopicName)
 }
 
@@ -309,7 +309,7 @@ func (s *EnqueueStompSuite) TestSendQueueWritePersistent(c *check.C) {
 	sc := enqueuestomp.SendConfig{}
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 
-	err = enqueue.SendQueue(queueName, queueBody, sc)
+	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -331,7 +331,7 @@ func (s *EnqueueStompSuite) TestSendQueueWithCircuitBreaker(c *check.C) {
 	sc := enqueuestomp.SendConfig{
 		CircuitName: "circuit-enqueuestomp",
 	}
-	err = enqueue.SendQueue(queueName, queueBody, sc)
+	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -350,7 +350,7 @@ func (s *EnqueueStompSuite) TestSendQueueWithWriteDisk(c *check.C) {
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendQueue(queueName, queueBody, sc)
+		err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -371,7 +371,7 @@ func (s *EnqueueStompSuite) TestSendTopic(c *check.C) {
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendTopic(topicName, topicBody, sc)
+		err = enqueue.SendTopic(topicName, topicBody, sc, nil)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -391,7 +391,7 @@ func (s *EnqueueStompSuite) TestSendTopicWithWriteDisk(c *check.C) {
 	total := 100
 	for i := 0; i < total; i++ {
 		sc := enqueuestomp.SendConfig{}
-		err = enqueue.SendTopic(topicName, topicBody, sc)
+		err = enqueue.SendTopic(topicName, topicBody, sc, nil)
 		c.Assert(err, check.IsNil)
 	}
 	s.waitQueueSize(enqueue)
@@ -427,7 +427,7 @@ func (s *EnqueueStompSuite) TestSendConfigOptions(c *check.C) {
 	sc.SetOptions(stomp.SendOpt.Header("persistent", "true"))
 	c.Assert(sc.Options, check.HasLen, 1)
 
-	err = enqueue.SendQueue(queueName, queueBody, sc)
+	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -450,7 +450,7 @@ func (s *EnqueueStompSuite) TestConfigOptions(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc)
+	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -467,7 +467,7 @@ func (s *EnqueueStompSuite) TestSendConfigLogger(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sc := enqueuestomp.SendConfig{}
-	err = enqueue.SendQueue(queueName, queueBody, sc)
+	err = enqueue.SendQueue(queueName, queueBody, sc, nil)
 	c.Assert(err, check.IsNil)
 	s.waitQueueSize(enqueue)
 
@@ -491,7 +491,7 @@ func (s *EnqueueStompSuite) TestSend(c *check.C) {
 		go func() {
 			defer wg.Done()
 			sc := enqueuestomp.SendConfig{}
-			err := enqueue.SendTopic(topicName, topicBody, sc)
+			err := enqueue.SendTopic(topicName, topicBody, sc, nil)
 			c.Assert(err, check.IsNil)
 		}()
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.15.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 )

--- a/log.go
+++ b/log.go
@@ -52,14 +52,20 @@ func (emq *EnqueueStomp) newOutput() (err error) {
 	return err
 }
 
-func (emq *EnqueueStomp) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte) {
+func (emq *EnqueueStomp) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte, logField LogField) {
 	if emq.hasOutput {
-		emq.output.Info(action,
+		fields := []zap.Field{
 			zap.String("identifier", identifier),
 			zap.String("destinationType", destinationType),
 			zap.String("destinationName", destinationName),
 			zap.ByteString("body", body),
-		)
+		}
+
+		if logField != nil && len(logField.getFields()) > 0 {
+			fields = append(fields, logField.getFields()...)
+		}
+
+		emq.output.Info(action, fields...)
 	}
 }
 

--- a/log.go
+++ b/log.go
@@ -27,7 +27,7 @@ func (l NoopLogger) Debugf(template string, args ...interface{}) {}
 // Errorf does nothing.
 func (l NoopLogger) Errorf(template string, args ...interface{}) {}
 
-func (emq *EnqueueStomp) newOutput() (err error) {
+func (emq *EnqueueStompImpl) newOutput() (err error) {
 	if emq.config.WriteOutputPath == "" {
 		return nil
 	}
@@ -52,7 +52,7 @@ func (emq *EnqueueStomp) newOutput() (err error) {
 	return err
 }
 
-func (emq *EnqueueStomp) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte, logField LogField) {
+func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte, logField LogField) {
 	if emq.hasOutput {
 		fields := []zap.Field{
 			zap.String("identifier", identifier),
@@ -69,10 +69,10 @@ func (emq *EnqueueStomp) writeOutput(action string, identifier string, destinati
 	}
 }
 
-func (emq *EnqueueStomp) debugLogger(template string, args ...interface{}) {
+func (emq *EnqueueStompImpl) debugLogger(template string, args ...interface{}) {
 	emq.log.Debugf(template, args...)
 }
 
-func (emq *EnqueueStomp) errorLogger(template string, args ...interface{}) {
+func (emq *EnqueueStompImpl) errorLogger(template string, args ...interface{}) {
 	emq.log.Errorf(template, args...)
 }

--- a/log.go
+++ b/log.go
@@ -52,7 +52,7 @@ func (emq *EnqueueStompImpl) newOutput() (err error) {
 	return err
 }
 
-func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte, logField LogField) {
+func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte) {
 	if emq.hasOutput {
 		fields := []zap.Field{
 			zap.String("identifier", identifier),
@@ -61,8 +61,8 @@ func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, desti
 			zap.ByteString("body", body),
 		}
 
-		if logField != nil && len(logField.getFields()) > 0 {
-			fields = append(fields, logField.getFields()...)
+		if emq.logField != nil && len(emq.logField.getFields()) > 0 {
+			fields = append(fields, emq.logField.getFields()...)
 		}
 
 		emq.output.Info(action, fields...)

--- a/log.go
+++ b/log.go
@@ -52,7 +52,7 @@ func (emq *EnqueueStompImpl) newOutput() (err error) {
 	return err
 }
 
-func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte) {
+func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte, logField LogField) {
 	if emq.hasOutput {
 		fields := []zap.Field{
 			zap.String("identifier", identifier),
@@ -61,8 +61,8 @@ func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, desti
 			zap.ByteString("body", body),
 		}
 
-		if emq.logField != nil && len(emq.logField.getFields()) > 0 {
-			fields = append(fields, emq.logField.getFields()...)
+		if logField != nil && len(logField.getFields()) > 0 {
+			fields = append(fields, logField.getFields()...)
 		}
 
 		emq.output.Info(action, fields...)

--- a/log_field.go
+++ b/log_field.go
@@ -3,7 +3,7 @@ package enqueuestomp
 import "go.uber.org/zap"
 
 type LogField interface {
-	SetNewField(key, value string)
+	setNewField(key, value string)
 	getFields() []zap.Field
 }
 
@@ -11,13 +11,13 @@ type LogFieldImpl struct {
 	fields map[string]string
 }
 
-func NewLogField() LogField {
+func newLogField() LogField {
 	return &LogFieldImpl{
 		fields: map[string]string{},
 	}
 }
 
-func (log *LogFieldImpl) SetNewField(key, value string) {
+func (log *LogFieldImpl) setNewField(key, value string) {
 	if len(key) > 0 {
 		log.fields[key] = value
 	}

--- a/log_field.go
+++ b/log_field.go
@@ -12,17 +12,23 @@ type LogFieldImpl struct {
 }
 
 func NewLogField() LogField {
-	return &LogFieldImpl{}
+	return &LogFieldImpl{
+		fields: map[string]string{},
+	}
 }
 
 func (log *LogFieldImpl) SetNewField(key, value string) {
-	log.fields[key] = value
+	if len(key) > 0 {
+		log.fields[key] = value
+	}
 }
 
 func (log *LogFieldImpl) getFields() []zap.Field {
 	var fields []zap.Field
-	for key, value := range log.fields {
-		fields = append(fields, zap.String(key, value))
+	if len(log.fields) > 0 {
+		for key, value := range log.fields {
+			fields = append(fields, zap.String(key, value))
+		}
 	}
 	return fields
 }

--- a/log_field.go
+++ b/log_field.go
@@ -1,0 +1,28 @@
+package enqueuestomp
+
+import "go.uber.org/zap"
+
+type LogField interface {
+	SetNewField(key, value string)
+	getFields() []zap.Field
+}
+
+type LogFieldImpl struct {
+	fields map[string]string
+}
+
+func NewLogField() LogField {
+	return &LogFieldImpl{}
+}
+
+func (log *LogFieldImpl) SetNewField(key, value string) {
+	log.fields[key] = value
+}
+
+func (log *LogFieldImpl) getFields() []zap.Field {
+	var fields []zap.Field
+	for key, value := range log.fields {
+		fields = append(fields, zap.String(key, value))
+	}
+	return fields
+}

--- a/log_field_test.go
+++ b/log_field_test.go
@@ -87,9 +87,9 @@ func TestLogField(t *testing.T) {
 		},
 	}
 	for index, testCase := range testCases {
-		logField := NewLogField()
+		logField := newLogField()
 		for _, input := range testCase.inputs {
-			logField.SetNewField(input.key, input.value)
+			logField.setNewField(input.key, input.value)
 		}
 		expectedResponse := logField.getFields()
 		assert.Subset(t, testCase.output.fields, expectedResponse, fmt.Sprintf("Test #%d [%s] failed. Wrong response.", index, testCase.name))

--- a/log_field_test.go
+++ b/log_field_test.go
@@ -1,0 +1,97 @@
+package enqueuestomp
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"testing"
+)
+
+func TestLogField(t *testing.T) {
+	type input struct {
+		key string
+		value string
+	}
+	type output struct {
+		fields []zap.Field
+	}
+	type testCase struct {
+		name string
+		inputs []input
+		output output
+	}
+	testCases := []testCase{
+		{
+			name: "Putting key and value should be OK",
+			inputs: []input{
+				input{
+					key: "testKey",
+					value: "testValue",
+				},
+			},
+			output: output{
+				fields: []zap.Field{
+					zap.String("testKey", "testValue"),
+				},
+			},
+		},
+		{
+			name: "Putting more than one key and value should be OK",
+			inputs: []input{
+				input{
+					key: "testKey",
+					value: "testValue",
+				},
+				input{
+					key: "testKey2",
+					value: "testValue2",
+				},
+				input{
+					key: "testKey3",
+					value: "testValue3",
+				},
+			},
+			output: output{
+				fields: []zap.Field{
+					zap.String("testKey", "testValue"),
+					zap.String("testKey2", "testValue2"),
+					zap.String("testKey3", "testValue3"),
+				},
+			},
+		},
+		{
+			name: "Putting empty key and value should be nil",
+			inputs: []input{
+				input{
+					key: "",
+					value: "testValue",
+				},
+			},
+			output: output{
+				fields: nil,
+			},
+		},
+		{
+			name: "Putting key and empty value should be OK",
+			inputs: []input{
+				input{
+					key: "testKey",
+					value: "",
+				},
+			},
+			output: output{
+				fields: []zap.Field{
+					zap.String("testKey", ""),
+				},
+			},
+		},
+	}
+	for index, testCase := range testCases {
+		logField := NewLogField()
+		for _, input := range testCase.inputs {
+			logField.SetNewField(input.key, input.value)
+		}
+		expectedResponse := logField.getFields()
+		assert.Subset(t, testCase.output.fields, expectedResponse, fmt.Sprintf("Test #%d [%s] failed. Wrong response.", index, testCase.name))
+	}
+}

--- a/sendconfig.go
+++ b/sendconfig.go
@@ -37,6 +37,8 @@ type SendConfig struct {
 	// the name of the CircuitBreaker.
 	// Default is empty
 	CircuitName string
+
+	logField LogField
 }
 
 func (sc *SendConfig) SetOptions(opts ...func(*frame.Frame) error) {
@@ -48,6 +50,13 @@ func (sc *SendConfig) AddOption(opt func(*frame.Frame) error) {
 		sc.Options = make([]func(*frame.Frame) error, 0)
 	}
 	sc.Options = append(sc.Options, opt)
+}
+
+func (sc *SendConfig) AddLogField(key, value string) {
+	if sc.logField == nil {
+		sc.logField = newLogField()
+	}
+	sc.logField.setNewField(key, value)
 }
 
 func (sc *SendConfig) init() {

--- a/suite_test.go
+++ b/suite_test.go
@@ -59,7 +59,7 @@ func (s *EnqueueStompSuite) TearDownTest(c *check.C) {
 	time.Sleep(20 * time.Millisecond)
 }
 
-func (s *EnqueueStompSuite) waitQueueSize(enqueue *enqueuestomp.EnqueueStomp) {
+func (s *EnqueueStompSuite) waitQueueSize(enqueue enqueuestomp.EnqueueStomp) {
 	for enqueue.QueueSize() > 0 {
 		time.Sleep(300 * time.Millisecond)
 	}


### PR DESCRIPTION
Before, you cannot pass fields to log:

```go
func (emq *EnqueueStomp) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte) {
	if emq.hasOutput {
		emq.output.Info(action,
			zap.String("identifier", identifier),
			zap.String("destinationType", destinationType),
			zap.String("destinationName", destinationName),
			zap.ByteString("body", body),
		)
	}
} 
```

Now, you can create many fields in log with it:

```go
func (emq *EnqueueStompImpl) writeOutput(action string, identifier string, destinationType string, destinationName string, body []byte, logField LogField) {
	if emq.hasOutput {
		fields := []zap.Field{
			zap.String("identifier", identifier),
			zap.String("destinationType", destinationType),
			zap.String("destinationName", destinationName),
			zap.ByteString("body", body),
		}

		if logField != nil && len(logField.getFields()) > 0 {
			fields = append(fields, logField.getFields()...)
		}

		emq.output.Info(action, fields...)
	}
}
```

to use logField you just do that:

```go
	enqueue, err := enqueuestomp.NewEnqueueStomp(
		enqueuestomp.Config{},
	)
	
	enqueue.ConfigureCircuitBreaker(
		"circuit-enqueuestomp",
		enqueuestomp.CircuitBreakerConfig{},
	)

	sc := enqueuestomp.SendConfig{
		CircuitName: "circuit-enqueuestomp",
	}

	sc.AddLogField("testKey", "testValue") // HERE YOU CAN SET THE KEY AND VALUE YOU WANT
	
	err = enqueue.SendQueue(queueName, queueBody, sc, logField)
```