### PR TITLE
update go.mod to use v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/globocom/enqueuestomp
+module github.com/globocom/enqueuestomp/v2
 
 go 1.14
 


### PR DESCRIPTION
update go.mod to `github.com/globocom/enqueuestomp/v2`